### PR TITLE
Make -b work better with ascii files

### DIFF
--- a/read20.c
+++ b/read20.c
@@ -496,17 +496,18 @@ void doDatablock (char *block)
 	else
 		ct = numbytes;
 
-	if (binflg) {
-		getwords(block, buf, 6, ct);
-		fwrite(buf, 5, ct, fpFile);
-	}
-	else if (bytesize == 7) {
+	if (bytesize == 7) {
 		nout = getstring(block, buf, 6, ct);
 		fwrite(buf, 1, nout, fpFile);
 	}
-	else {          /* if not 7, then 8bit */
+	else if (bytesize == 8) {          /* if not 7, then 8bit */
 		getbytes(block, buf, 6, ct);
 		fwrite(buf, 1, ct, fpFile);
+	}
+	else if (binflg) {
+	        /* Only treat it as binary if it isn't 7 or 8-bit bytes */
+		getwords(block, buf, 6, ct);
+		fwrite(buf, 5, ct, fpFile);
 	}
 	if (ferror(fpFile))
 		punt(1, "Error writing %s", sunixname);
@@ -682,7 +683,8 @@ void doFileHeader (char *block)
 	}
 
 	if (xflg) {
-	    if (binflg) {
+	    if (binflg && bytesize != 7 && bytesize != 8) {
+	        /* Hack bytesize of binary files only if they aren't 7 or 8-bit */
 		if (bytesize == 0)
 		    bytesize = 36;
 	        numbytes = (numbytes + (36/bytesize) - 1) / (36 / bytesize);


### PR DESCRIPTION
**Problem:** when extracting e.g. the Panda tape image with -b to get *all* the files, many ascii files get trailing NULs (those whose length is not a multiple of 5 bytes) even when they don't actually contain trailing NULs on the tape file. The file length when read is also wrong, rounded up to a multiple of 5.

**Example:** with https://github.com/PDP-10/panda/blob/master/tape-image/panda.tap.bz2 uncompressed, do
```read20 -c -b -x -v -f panda.tap -e exec1.mac```
The resulting file (exec-sources/exec1.mac) should have length 151281, but instead ends up with length 151285 where the last bytes are NULs.

This leads to at least two problems: 
1. the extracted data is not what the tape actually contains
2. the extracted files confuse tools like diff, or Github Desktop, which doesn't want show diffs (because it thinks the file is binary).

The **reason** for the trailing NULs is that with -b, *all* files are extracted as binary (bytesize 36) even though the FDB on the tape says they are 7- or 8-bit..

The **suggested fix** is to 
1. with -b, only hack the bytesize of files if it isn't 7 or 8
2. change the order of the cases in doDatablock to only treat files as binary if they aren't 7- or 8-bit.

The **result** is that when extracting files from tape images, the files get the correct length without trailing NULs.